### PR TITLE
bump qemu-server to 8.3.2

### DIFF
--- a/packages/qemu-server/autobuild.sh
+++ b/packages/qemu-server/autobuild.sh
@@ -6,5 +6,9 @@ echo "This is $PKGNAME build scripts"
 
 . ../common.sh
 
+apt update
+apt install  libglib2.0-dev libjson-c-dev libtest-mockmodule-perl pve-doc-generator pve-edk2-firmware -y
+sed -i "s/-b /& -d /" $SCRIPT_DIR/$PKGNAME/Makefile
+
 cd $SCRIPT_DIR/$PKGNAME
 exec_build_make


### PR DESCRIPTION
Because of software source conflicts, we need to update qemu-server 8.3.2 to compile automatically normally, but we are currently compiling 8.3.2, so we ignore the version dependency of pve-storage so that we can build normally and compile for version 8.3.3.