### PR TITLE
bump qemu-server to 8.3.3+port

### DIFF
--- a/packages/qemu-server/autobuild.sh
+++ b/packages/qemu-server/autobuild.sh
@@ -6,9 +6,5 @@ echo "This is $PKGNAME build scripts"
 
 . ../common.sh
 
-apt update
-apt install  libglib2.0-dev libjson-c-dev libtest-mockmodule-perl pve-doc-generator pve-edk2-firmware -y
-sed -i "s/-b /& -d /" $SCRIPT_DIR/$PKGNAME/Makefile
-
 cd $SCRIPT_DIR/$PKGNAME
 exec_build_make

--- a/packages/qemu-server/patches/002-add-port-changelog.patch
+++ b/packages/qemu-server/patches/002-add-port-changelog.patch
@@ -1,0 +1,29 @@
+diff --git a/debian/changelog b/debian/changelog
+index 1439b7f3..0b93b9e8 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -27,6 +27,24 @@ qemu-server (8.3.1) bookworm; urgency=medium
+ 
+  -- Proxmox Support Team <support@proxmox.com>  Thu, 05 Dec 2024 12:38:12 +0100
+ 
++qemu-server (8.3.0+port3) bookworm; urgency=medium
++
++  * Add loongarch efi_vars support
++
++ -- Jiangcuo <jiangcuo@lierfang.com>  Wed, 11 Dec 2024 13:44:37 +0800
++
++qemu-server (8.3.0+port2) bookworm; urgency=medium
++
++  * Fix usb hotplug error
++
++ -- Jiangcuo <jiangcuo@bingsin.com>  Mon, 09 Dec 2024 16:30:48 +0800
++
++qemu-server (8.3.0+port1) bookworm; urgency=medium
++
++  * Fix cpu type on loongarch64
++
++ -- Jiangcuo <jiangcuo@bingsin.com>  Thu, 05 Dec 2024 14:16:44 +0800
++
+ qemu-server (8.3.0) bookworm; urgency=medium
+ 
+   * api: import working storage: improve error message

--- a/packages/qemu-server/patches/005-bump-version-to-8.3.2.patch
+++ b/packages/qemu-server/patches/005-bump-version-to-8.3.2.patch
@@ -1,0 +1,19 @@
+diff --git a/debian/changelog b/debian/changelog
+index 0b93b9e8..dbb548be 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -18,6 +18,14 @@ qemu-server (8.3.2) bookworm; urgency=medium
+ 
+  -- Proxmox Support Team <support@proxmox.com>  Mon, 09 Dec 2024 10:08:14 +0100
+ 
++qemu-server (8.3.1+port) bookworm; urgency=medium
++
++  * Set default bios type to ovmf when vm create
++   
++  * Add Kunpeng920 cpu model.
++
++ -- Jiangcuo <Jiangcuo@lierfang.com>  Thu, 26 Dec 2024 11:22:33 +0800
++
+ qemu-server (8.3.1) bookworm; urgency=medium
+ 
+   * api: clone vm: make error for unsupported volumes appear in a

--- a/packages/qemu-server/patches/006-bump-qemu-server-to-8.3.2+port.patch
+++ b/packages/qemu-server/patches/006-bump-qemu-server-to-8.3.2+port.patch
@@ -1,0 +1,17 @@
+diff --git a/debian/changelog b/debian/changelog
+index dbb548be..afdaaa98 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -12,6 +12,12 @@ qemu-server (8.3.3) bookworm; urgency=medium
+ 
+  -- Proxmox Support Team <support@proxmox.com>  Sun, 15 Dec 2024 14:26:32 +0100
+ 
++qemu-server (8.3.2+port) bookworm; urgency=medium
++
++  * Add port verison
++
++ -- Jiangcuo <Jiangcuo@lierfang.com>  Thu, 26 Dec 2024 11:28:33 +0800
++
+ qemu-server (8.3.2) bookworm; urgency=medium
+ 
+   * use image format from storage layer for PVE-managed volumes

--- a/packages/qemu-server/patches/007-bump-version-to-8.3.3+port.patch
+++ b/packages/qemu-server/patches/007-bump-version-to-8.3.3+port.patch
@@ -1,0 +1,23 @@
+diff --git a/debian/changelog b/debian/changelog
+index afdaaa98..87012a2a 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,3 +1,9 @@
++qemu-server (8.3.3+port) bookworm; urgency=medium
++
++  * Add port version
++
++ -- Jiangcuo <Jiangcuo@lierfang.com>  Thu, 26 Dec 2024 12:13:33 +0800
++
+ qemu-server (8.3.3) bookworm; urgency=medium
+ 
+   * fix #5980: import disk: fix spurious warning if no target disk is defined
+@@ -14,7 +20,7 @@ qemu-server (8.3.3) bookworm; urgency=medium
+ 
+ qemu-server (8.3.2+port) bookworm; urgency=medium
+ 
+-  * Add port verison
++  * Add port version
+ 
+  -- Jiangcuo <Jiangcuo@lierfang.com>  Thu, 26 Dec 2024 11:28:33 +0800
+ 

--- a/packages/qemu-server/patches/009-add-gicversion-param.patch
+++ b/packages/qemu-server/patches/009-add-gicversion-param.patch
@@ -1,0 +1,53 @@
+diff --git a/PVE/API2/Qemu.pm b/PVE/API2/Qemu.pm
+index e1dc3e7e..d21fb6ed 100644
+--- a/PVE/API2/Qemu.pm
++++ b/PVE/API2/Qemu.pm
+@@ -684,6 +684,7 @@ my $generaloptions = {
+     'name' => 1,
+     'onboot' => 1,
+     'ostype' => 1,
++	'gicversion' =>1,
+     'protection' => 1,
+     'reboot' => 1,
+     'startdate' => 1,
+diff --git a/PVE/QemuServer.pm b/PVE/QemuServer.pm
+index 6f0d41fc..d351dfbc 100644
+--- a/PVE/QemuServer.pm
++++ b/PVE/QemuServer.pm
+@@ -420,6 +420,12 @@ my $confdesc = {
+ 	type => 'string',
+ 	description => "Memory properties.",
+ 	format => $PVE::QemuServer::Memory::memory_fmt
++    },
++	gicversion => {
++    optional => 1,
++    type => 'string',
++    description => "Set virt gic-version",
++    enum => [qw(host 2 3 4 max)],
+     },
+     'amd-sev' => {
+ 	description => "Secure Encrypted Virtualization (SEV) features by AMD CPUs",
+@@ -4279,14 +4285,17 @@ sub config_to_command {
+     my $machine_type_min = $machine_type;
+     $machine_type_min =~ s/\+pve\d+$//;
+     $machine_type_min .= "+pve$required_pve_version";
++
++
++	my $gicv = $kvm ? 'host' : 'max';
++    if ( $conf->{gicversion} ) {
++        $gicv = $conf->{gicversion};
++    } 
++
+     if ($arch eq 'aarch64'){
+-	if (!$kvm){
+-        push @$machineFlags, "type=${machine_type_min}";
+-	}else{
+-	 push @$machineFlags, "type=${machine_type_min},gic-version=host";
+-	}
++		push @$machineFlags, "type=${machine_type_min},gic-version=${gicv}";
+     }else{
+-       push @$machineFlags, "type=${machine_type_min}";
++    	push @$machineFlags, "type=${machine_type_min}";
+     }
+ 
+ 	# This method is prevented from being executed on the Port branch.

--- a/packages/qemu-server/patches/010-bump-version-to-8.3.3+port2.patch
+++ b/packages/qemu-server/patches/010-bump-version-to-8.3.3+port2.patch
@@ -1,0 +1,14 @@
+diff --git a/debian/changelog b/debian/changelog
+index 87012a2a..caf93620 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,3 +1,9 @@
++qemu-server (8.3.3+port2) bookworm; urgency=medium
++
++  * Add 'gicversion' param.
++
++ -- Jiangcuo <Jiangcuo@lierfang.com>  Thu, 26 Dec 2024 12:28:33 +0800
++
+ qemu-server (8.3.3+port) bookworm; urgency=medium
+ 
+   * Add port version

--- a/packages/qemu-server/series
+++ b/packages/qemu-server/series
@@ -1,3 +1,9 @@
 patches/001-init-for-port.patch
+patches/002-add-port-changelog.patch
 patches/003-set-default-bios-to-ovmf-when-vm-create.diff
 patches/004-add-Kunpeng-920-cpu-model.patch
+patches/005-bump-version-to-8.3.2.patch
+patches/006-bump-qemu-server-to-8.3.2+port.patch
+patches/007-bump-version-to-8.3.3+port.patch
+patches/009-add-gicversion-param.patch
+patches/010-bump-version-to-8.3.3+port2.patch


### PR DESCRIPTION
I added a gicversion parameter, the user can control the gic version passed to the arm virtual machine。
The gic version defaults to `host` when kvm is enabled, and `max` if tcg is enabled. 
Of course, you can override it with
 ```bash
qm set <vmid> --gicversion [2,3,4,host,max]
```